### PR TITLE
add filtering capabilities

### DIFF
--- a/conf.d/source.containers.conf
+++ b/conf.d/source.containers.conf
@@ -25,4 +25,8 @@
   source_category "#{ENV['SOURCE_CATEGORY']}"
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
+  exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_pod_regex "#{ENV['EXCLUDE_POD_REGEX']}"
+  exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
+  exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
 </filter>

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -12,6 +12,10 @@ module Fluent
     config_param :source_name, :string, :default => '%{namespace}.%{pod}.%{container}'
     config_param :log_format, :string, :default => 'json'
     config_param :source_host, :string, :default => nil
+    config_param :exclude_namespace_regex, :string, :default => nil
+    config_param :exclude_pod_regex, :string, :default => nil
+    config_param :exclude_container_regex, :string, :default => nil
+    config_param :exclude_host_regex, :string, :default => nil
 
     def configure(conf)
       super
@@ -48,6 +52,30 @@ module Fluent
             :source_host => kubernetes['host'],
         }
 
+        unless @exclude_namespace_regex.empty?
+          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace])
+            return nil
+          end
+        end
+
+        unless @exclude_pod_regex.empty?
+          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod])
+            return nil
+          end
+        end
+
+        unless @exclude_container_regex.empty?
+          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container])
+            return nil
+          end
+        end
+
+        unless @exclude_host_regex.empty?
+          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host])
+            return nil
+          end
+        end
+
         # Strip out dynamic bits from pod name.
         # NOTE: Kubernetes deployments append a template hash.
         pod_parts = k8s_metadata[:pod].split('-')
@@ -58,6 +86,10 @@ module Fluent
         end
 
         annotations = kubernetes.fetch('annotations', {})
+
+        if annotations['sumologic.com/excludeFromSumo'] == 'true'
+          return nil
+        end
 
         sumo_metadata[:log_format] = annotations['sumologic.com/format'] if annotations['sumologic.com/format']
         sumo_metadata[:host] = k8s_metadata[:source_host] if k8s_metadata[:source_host]


### PR DESCRIPTION
You can now control the data that comes to Sumo Logic.  First, you can use the annotation sumologic.com/excludeFromSumo to prevent a pod from going to sumo.  In addition, you can add some environment variables to the fluentd.daemonset.yaml to filter logs from the cluster.  You can do this by providing a regex pattern to apply to the namespace, pod, container or host.