### PR TITLE
read_from_head value in source.containers.conf is taken from ENV.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV SOURCE_CATEGORY_PREFIX "kubernetes/"
 ENV SOURCE_CATEGORY_REPLACE_DASH "/"
 ENV SOURCE_NAME "%{namespace}.%{pod}.%{container}"
 ENV KUBERNETES_META "true"
+ENV READ_FROM_HEAD "false"
 
 COPY ./conf.d/* /fluentd/conf.d/
 COPY ./etc/* /fluentd/etc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV SOURCE_CATEGORY_PREFIX "kubernetes/"
 ENV SOURCE_CATEGORY_REPLACE_DASH "/"
 ENV SOURCE_NAME "%{namespace}.%{pod}.%{container}"
 ENV KUBERNETES_META "true"
-ENV READ_FROM_HEAD "false"
+ENV READ_FROM_HEAD "true"
 
 COPY ./conf.d/* /fluentd/conf.d/
 COPY ./etc/* /fluentd/etc/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following options can be configured as environment variables on the DaemonSe
   * json - Logs will appear in SumoLogic in json format.
   * json_merge - Same as json but if the container logs in json format to stdout it will merge in the container json log at the root level and remove the `log` field.
 * `KUBERNETES_META` - Include or exclude Kubernetes metadata such as namespace and pod_name if using json log format. (default `true`)
+* `READ_FROM_HEAD` - Start to read the logs from the head of file, not bottom. (default `false`). See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#readfromhead) doc for more information.
 * `EXCLUDE_PATH` - Files matching this pattern will be ignored by the in_tail plugin, and will not be sent to Kubernetes or Sumo Logic.  This can be a comma seperated list as well.  See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#excludepath) doc for more information.
   * For example, setting EXCLUDE_PATH to the following would ignore all files matching /var/log/containers/*.log
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following options can be configured as environment variables on the DaemonSe
   * json - Logs will appear in SumoLogic in json format.
   * json_merge - Same as json but if the container logs in json format to stdout it will merge in the container json log at the root level and remove the `log` field.
 * `KUBERNETES_META` - Include or exclude Kubernetes metadata such as namespace and pod_name if using json log format. (default `true`)
-* `READ_FROM_HEAD` - Start to read the logs from the head of file, not bottom. (default `true`). See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#readfromhead) doc for more information.
+* `READ_FROM_HEAD` - Start to read the logs from the head of file, not bottom. Only applies to containers log files. (default `true`). See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#readfromhead) doc for more information.
 * `EXCLUDE_PATH` - Files matching this pattern will be ignored by the in_tail plugin, and will not be sent to Kubernetes or Sumo Logic.  This can be a comma seperated list as well.  See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#excludepath) doc for more information.
   * For example, setting EXCLUDE_PATH to the following would ignore all files matching /var/log/containers/*.log
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following options can be configured as environment variables on the DaemonSe
   * json - Logs will appear in SumoLogic in json format.
   * json_merge - Same as json but if the container logs in json format to stdout it will merge in the container json log at the root level and remove the `log` field.
 * `KUBERNETES_META` - Include or exclude Kubernetes metadata such as namespace and pod_name if using json log format. (default `true`)
-* `READ_FROM_HEAD` - Start to read the logs from the head of file, not bottom. (default `false`). See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#readfromhead) doc for more information.
+* `READ_FROM_HEAD` - Start to read the logs from the head of file, not bottom. (default `true`). See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#readfromhead) doc for more information.
 * `EXCLUDE_PATH` - Files matching this pattern will be ignored by the in_tail plugin, and will not be sent to Kubernetes or Sumo Logic.  This can be a comma seperated list as well.  See [in_tail](http://docs.fluentd.org/v0.12/articles/in_tail#excludepath) doc for more information.
   * For example, setting EXCLUDE_PATH to the following would ignore all files matching /var/log/containers/*.log
 ```

--- a/conf.d/source.containers.conf
+++ b/conf.d/source.containers.conf
@@ -7,7 +7,7 @@
   pos_file /mnt/pos/ggcp-containers.log.pos
   time_format %Y-%m-%dT%H:%M:%S.%NZ
   tag containers.*
-  read_from_head true
+  read_from_head "#{ENV['READ_FROM_HEAD']}"
 </source>
 
 <filter containers.**>


### PR DESCRIPTION
We ran the fluentd collector on our k8s cluster today and within 5mins we were throttled by SumoLogic because we pushed too many logs. This was mainly caused by `read_from_head` being set to true on containers logs. I think many people are under the impression that the collector only pushes new logs into SumoLogic, not historical ones. This can also cause duplicate logs in SumoLogic if the fluentd containers are restarted.