### PR TITLE
Split logs between gpubsub and sumo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM fluent/fluentd:v0.12.34
+FROM fluent/fluentd:debian
 WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 
 USER root
 
-RUN apk --no-cache --update add sudo build-base ruby-dev libffi-dev && \
-    sudo -u fluent gem install fluent-plugin-record-reformer fluent-plugin-kubernetes_metadata_filter fluent-plugin-sumologic_output && \
-    rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && sudo -u fluent gem sources -c && \
-    apk del sudo build-base ruby-dev && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y sudo build-essential ruby-dev libffi-dev && \
+    gem install fluent-plugin-record-reformer fluent-plugin-kubernetes_metadata_filter fluent-plugin-sumologic_output fluent-plugin-gcloud-pubsub-custom && \
+    rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && gem sources -c
+
+    #  && \
+    # apk del sudo build-base ruby-dev && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /mnt/pos
 EXPOSE 24284
@@ -31,4 +33,6 @@ COPY ./conf.d/* /fluentd/conf.d/
 COPY ./etc/* /fluentd/etc/
 COPY ./plugins/* /fluentd/plugins/
 
-CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
+ENTRYPOINT []
+
+CMD fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT

--- a/conf.d/out.gpubsub.conf
+++ b/conf.d/out.gpubsub.conf
@@ -1,0 +1,7 @@
+<store>
+  @type gcloud_pubsub
+  project "#{ENV['GCP_PROJECT_ID']}"
+  key "#{ENV['GOOGLE_APPLICATION_CREDENTIALS']}"
+  topic "#{ENV['PUBSUB_TOPIC']}"
+  flush_interval "#{ENV['FLUSH_INTERVAL']}"
+</store>

--- a/conf.d/out.sumo.conf
+++ b/conf.d/out.sumo.conf
@@ -1,9 +1,9 @@
-<match **>
- type sumologic
- log_key log
- endpoint "#{ENV['COLLECTOR_URL']}"
- verify_ssl "#{ENV['VERIFY_SSL']}"
- log_format "#{ENV['LOG_FORMAT']}"
- flush_interval "#{ENV['FLUSH_INTERVAL']}"
- num_threads "#{ENV['NUM_THREADS']}"
-</match>
+<store>
+  type sumologic
+  log_key log
+  endpoint "#{ENV['COLLECTOR_URL']}"
+  verify_ssl "#{ENV['VERIFY_SSL']}"
+  log_format "#{ENV['LOG_FORMAT']}"
+  flush_interval "#{ENV['FLUSH_INTERVAL']}"
+  num_threads "#{ENV['NUM_THREADS']}"
+</store>

--- a/etc/fluent.conf
+++ b/etc/fluent.conf
@@ -3,4 +3,9 @@
 </match>
 
 @include /fluentd/conf.d/source.*.conf
-@include /fluentd/conf.d/out.sumo.conf
+
+<match **>
+  @type copy
+  @include /fluentd/conf.d/out.sumo.conf
+  @include /fluentd/conf.d/out.gpubsub.conf
+</match>

--- a/fluentd.daemonset.yaml
+++ b/fluentd.daemonset.yaml
@@ -20,8 +20,11 @@ spec:
       - name: docker-logs
         hostPath:
           path: /var/lib/docker
+      - name: gcloud
+        secret:
+          secretName: sumologic
       containers:
-      - image: sumologic/fluentd-kubernetes-sumologic:latest
+      - image: gcr.io/driverinc-sandbox/sumologic:0.0.1-7
         name: fluentd
         imagePullPolicy: Always
         volumeMounts:
@@ -36,9 +39,27 @@ spec:
           readOnly: true
         - name: pos-files
           mountPath: /mnt/pos/
+        - name: gcloud
+          mountPath: /etc/gcloud/
+          readOnly: true
         env:
+        - name: SOURCE_CATEGORY_PREFIX
+          value: sandbox/
+        - name: SOURCE_CATEGORY
+          value: kubernetes
+        - name: LOG_FORMAT
+          value: json_merge
+        - name: SOURCE_NAME
+          value: '%{container}.%{namespace}'
         - name: COLLECTOR_URL
           valueFrom:
             secretKeyRef:
               name: sumologic
               key: collector-url
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/gcloud/google-application-credentials
+        - name: GCP_PROJECT_ID
+          value: driverinc-sandbox
+        - name: PUBSUB_TOPIC
+          value: fluentd-k8s
+        


### PR DESCRIPTION
Used the copy function to duplicate logs between sumo and pubsub. Also needed to switch from alpine to debian and make the container run as root in order to get the pubsub fluentd plugin working. Other than that, pretty straightforward.