### PR TITLE
Enable monitoring endpoints

### DIFF
--- a/etc/fluent.conf
+++ b/etc/fluent.conf
@@ -2,5 +2,11 @@
   type null
 </match>
 
+<source>
+  @type monitor_agent
+  bind 0.0.0.0
+  port 24220
+</source>
+
 @include /fluentd/conf.d/source.*.conf
 @include /fluentd/conf.d/out.sumo.conf


### PR DESCRIPTION
This enables monitoring endpoints so we can monitor fluentd's performance.