### PR TITLE
Add support for detecting and loading runtime changes of exclude regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The following options can be configured as environment variables on the DaemonSe
  * `EXCLUDE_POD_REGEX` - A Regex pattern for pods.  All matching pods will be excluded from Sumo Logic.  The logs will still be sent to FluentD.
  * `EXCLUDE_CONTAINER_REGEX` - A Regex pattern for containers.  All matching containers will be excluded from Sumo Logic.  The logs will still be sent to FluentD.
  * `EXCLUDE_HOST_REGEX` - A Regex pattern for hosts.  All matching hosts will be excluded from Sumo Logic.  The logs will still be sent to FluentD.
+ * `EXCLUDE_CONFIG_PATH` - Path to a YAML config file to use in lieu of `EXCLUDE_NAMESPACE_REGEX`, `EXCLUDE_POD_REGEX`, `EXCLUDE_CONTAINER_REGEX`, `EXCLUDE_HOST_REGEX`. The specified file is monitored for changes and the values are reloaded upon change. The expected format is:
+ ```
+exclude_namespace_regex: "some regex"
+exclude_pod_regex: "some regex"
+exclude_container_regex: "some regex"
+exclude_host_regex: "some regex"
+ ```
+
 
 The following table show which  environment variables affect fluent sources
 

--- a/conf.d/source.containers.conf
+++ b/conf.d/source.containers.conf
@@ -30,4 +30,5 @@
   exclude_pod_regex "#{ENV['EXCLUDE_POD_REGEX']}"
   exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>

--- a/conf.d/source.kubernetes.conf
+++ b/conf.d/source.kubernetes.conf
@@ -16,6 +16,7 @@
   source_name k8s_salt
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>
 
 
@@ -64,6 +65,7 @@
   source_name k8s_kubelet
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>
 
 # Example:
@@ -111,6 +113,7 @@
   source_name k8s_kube-controller-manager
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>
 
 
@@ -135,6 +138,7 @@
   source_name k8s_kube-scheduler
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>
 
 
@@ -160,6 +164,7 @@
   source_name k8s_glbc
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>
 
 
@@ -185,4 +190,5 @@
   source_name k8s_cluster-autoscaler
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
   exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+  exclude_config_path "#{ENV['EXCLUDE_CONFIG_PATH']}"
 </filter>

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -48,7 +48,7 @@ module Fluent
       return if @exclude_config_path.nil? || @exclude_config_path.empty?
       
       @loop = Coolio::Loop.new
-      @conf_trigger = ConfigWatcher.new(@exclude_config_path, log, &method(:load_exclude_config))
+      @conf_trigger = ConfigWatcher.new(File.dirname(@exclude_config_path), log, &method(:load_exclude_config))
       @conf_trigger.attach(@loop)
       @thread = Thread.new(&method(:run))
     end

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -35,10 +35,11 @@ module Fluent
       return if not conf 
       $log.info "parsed exclude config: #{conf}"
 
-      @exclude_namespace_regex = conf['exclude_namespace_regex'] if conf.has_key? 'exclude_namespace_regex'
-      @exclude_pod_regex = conf['exclude_pod_regex'] if conf.has_key? 'exclude_pod_regex'
-      @exclude_container_regex = conf['exclude_container_regex'] if conf.has_key? 'exclude_container_regex'
-      @exclude_host_regex = conf['exclude_host_regex'] if conf.has_key? 'exclude_host_regex'
+      @exclude_namespace_regex = conf['exclude_namespace_regex'] || ""
+      @exclude_pod_regex = conf['exclude_pod_regex'] || ""
+      @exclude_container_regex = conf['exclude_container_regex'] || ""
+      @exclude_host_regex = conf['exclude_host_regex'] || ""
+
     rescue 
       @log.error $!.to_s
       @log.error_backtrace


### PR DESCRIPTION
This PR adds support for detecting and loading runtime changes of exclude regexes. This is done by monitoring a YAML file located at the path specified in the `EXCLUDE_CONFIG_PATH`. In practice, the contents of the YAML file should be specified in a config map that is mounted as a volume at the path specified by `EXCLUDE_CONFIG_PATH`.

For example:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: fluentd-sumologic-excludes
data:
  excludes.yaml: "exclude_namespace_regex: \"(^namespace)\"\nexclude_pod_regex:
    \"(^pod)\"\nexclude_container_regex: \nexclude_host_regex: "
---
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  name: fluentd
  labels:
    app: fluentd
    version: v1
spec:
  template:
    metadata:
      labels:
        name: fluentd
    spec:
      volumes:
...
      - name: excludes
        configMap:
          name: fluentd-sumologic-excludes
      containers:
...
        volumeMounts:
...
        - name: excludes
          mountPath: /fluentd/etc/excludes
          readOnly: true
        env:
...
        - name: EXCLUDE_CONFIG_PATH
           value: "/fluentd/etc/excludes/excludes.yaml"        
```