### PR TITLE
Fix typo in sumologic kubernetes filter

### DIFF
--- a/conf.d/systemd/source.systemd.conf
+++ b/conf.d/systemd/source.systemd.conf
@@ -16,7 +16,7 @@
   source_category system
   source_name addon-config
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -39,7 +39,7 @@
   source_category system
   source_name addon-run
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -62,7 +62,7 @@
   source_category system
   source_name cfn-etcd-environment
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -85,7 +85,7 @@
   source_category system
   source_name cfn-signal
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -108,7 +108,7 @@
   source_category system
   source_name clean-ca-certificates
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -131,7 +131,7 @@
   source_category system
   source_name containerd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -154,7 +154,7 @@
   source_category system
   source_name coreos-metadata
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -177,7 +177,7 @@
   source_category system
   source_name coreos-setup-environment
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -200,7 +200,7 @@
   source_category system
   source_name coreos-tmpfiles
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -223,7 +223,7 @@
   source_category system
   source_name dbus
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -246,7 +246,7 @@
   source_category system
   source_name docker
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -269,7 +269,7 @@
   source_category system
   source_name efs
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -292,7 +292,7 @@
   source_category system
   source_name etcd-member
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -315,7 +315,7 @@
   source_category system
   source_name etcd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -338,7 +338,7 @@
   source_category system
   source_name etcd2
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -361,7 +361,7 @@
   source_category system
   source_name etcd3
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -384,7 +384,7 @@
   source_category system
   source_name etcdadm-check
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -407,7 +407,7 @@
   source_category system
   source_name etcdadm-reconfigure
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -430,7 +430,7 @@
   source_category system
   source_name etcdadm-save
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -453,7 +453,7 @@
   source_category system
   source_name etcdadm-update-status
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -476,7 +476,7 @@
   source_category system
   source_name flanneld
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -499,7 +499,7 @@
   source_category system
   source_name format-etcd2-volume
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -522,7 +522,7 @@
   source_category system
   source_name kube-node-taint-and-uncordon
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -572,7 +572,7 @@
   source_category system
   source_name ldconfig
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -595,7 +595,7 @@
   source_category system
   source_name locksmithd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -618,7 +618,7 @@
   source_category system
   source_name logrotate
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -641,7 +641,7 @@
   source_category system
   source_name lvm2-monitor
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -664,7 +664,7 @@
   source_category system
   source_name mdmon
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -687,7 +687,7 @@
   source_category system
   source_name nfs-idmapd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -710,7 +710,7 @@
   source_category system
   source_name nfs-mountd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -733,7 +733,7 @@
   source_category system
   source_name nfs-server
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -756,7 +756,7 @@
   source_category system
   source_name nfs-utils
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -779,7 +779,7 @@
   source_category system
   source_name oem-cloudinit
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -802,7 +802,7 @@
   source_category system
   source_name rkt-gc
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -825,7 +825,7 @@
   source_category system
   source_name rkt-metadata
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -848,7 +848,7 @@
   source_category system
   source_name rpc-idmapd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -871,7 +871,7 @@
   source_category system
   source_name rpc-mountd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -894,7 +894,7 @@
   source_category system
   source_name rpc-statd
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -917,7 +917,7 @@
   source_category system
   source_name rpcbind
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -940,7 +940,7 @@
   source_category system
   source_name set-aws-environment
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -963,7 +963,7 @@
   source_category system
   source_name system-cloudinit
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -986,7 +986,7 @@
   source_category system
   source_name update-ca-certificates
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -1009,7 +1009,7 @@
   source_category system
   source_name user-cloudinit
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
@@ -1032,7 +1032,7 @@
   source_category system
   source_name var-lib-etcd2
   source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-  exclude_facliity_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
   exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -53,7 +53,7 @@ module Fluent
         end
 
         unless @exclude_facility_regex.empty?
-          if Regexp.compile(@exclude_facliity_regex).match(record['SYSLOG_FACILITY'])
+          if Regexp.compile(@exclude_facility_regex).match(record['SYSLOG_FACILITY'])
             return nil
           end
         end


### PR DESCRIPTION
## what

Fix typo in sumologic kubernetes filter

`exclude_facility_regex` was misspelled in a several places

## why

From logs:

```
2018-03-06 21:53:40 +0000 [warn]: parameter 'exclude_facliity_regex' in <filter user-cloudinit.**>
  @type kubernetes_sumologic
  source_category "system"
  source_name "user-cloudinit"
  source_category_prefix ".../"
  exclude_facliity_regex
  exclude_host_regex ""
  exclude_priority_regex ""
  exclude_unit_regex ""
</filter> is not used.
```