### PR TITLE
Add namespaces to resources list

### DIFF
--- a/daemonset/rbac/fluentd.yaml
+++ b/daemonset/rbac/fluentd.yaml
@@ -13,6 +13,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - pods
   verbs:
   - get


### PR DESCRIPTION
Fix for issues [#55](https://github.com/SumoLogic/fluentd-kubernetes-sumologic/issues/55)

Added "namespaces" to the list of resources