### PR TITLE
Allow hand picked data to be sent to sumo when certain exclusions apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The plugin runs as a Kubernetes [DaemonSet](http://kubernetes.io/docs/admin/daem
 - [Environment variables](#environment-variables)
     + [Override environment variables using annotations](#override-environment-variables-using-annotations)
     + [Exclude data using annotations](#exclude-data-using-annotations)
+    + [Include excluded using annotations](#include-excluded-using-annotations)
 - [Step 4 Set up Heapster for metric collection](#step-4-set-up-heapster-for-metric-collection)
   * [Kubernetes ConfigMap](#kubernetes-configmap)
   * [Kubernetes Service](#kubernetes-service)
@@ -170,6 +171,37 @@ spec:
         sumologic.com/sourceCategory: "mywebsite/nginx"
         sumologic.com/sourceName: "mywebsite_nginx"
         sumologic.com/exclude: "true"
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+```
+
+### Include excluded using annotations
+
+If you excluded a whole namespace, but still need one or few pods to be still included for shipping to Sumologic, you can use the `sumologic.com/include` annotation to include data to Sumo. It takes precedence over the exclusion described above.
+
+```
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    app: mywebsite
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: mywebsite
+      annotations:
+        sumologic.com/format: "text"
+        sumologic.com/sourceCategory: "mywebsite/nginx"
+        sumologic.com/sourceName: "mywebsite_nginx"
+        sumologic.com/include: "true"
     spec:
       containers:
       - name: nginx

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -83,26 +83,34 @@ module Fluent
             :source_host => kubernetes['host'],
         }
 
+        annotations = kubernetes.fetch('annotations', {})
+
+        if annotations['sumologic.com/include'] == 'true'
+          include = true
+        else
+          include = false
+        end
+        
         unless @exclude_namespace_regex.empty?
-          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace])
+          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace]) and not include
             return nil
           end
         end
 
         unless @exclude_pod_regex.empty?
-          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod])
+          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod]) and not include
             return nil
           end
         end
 
         unless @exclude_container_regex.empty?
-          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container])
+          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container]) and not include
             return nil
           end
         end
 
         unless @exclude_host_regex.empty?
-          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host])
+          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host]) and not include
             return nil
           end
         end
@@ -115,8 +123,6 @@ module Fluent
         else
           k8s_metadata[:pod_name] = pod_parts[0..-2].join('-')
         end
-
-        annotations = kubernetes.fetch('annotations', {})
 
         if annotations['sumologic.com/exclude'] == 'true'
           return nil

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -1,10 +1,10 @@
 require 'fluent/filter'
-
+ 
 module Fluent
   class SumoContainerOutput < Filter
     # Register type
     Fluent::Plugin.register_filter('kubernetes_sumologic', self)
-
+ 
     config_param :kubernetes_meta, :bool, :default => true
     config_param :source_category, :string, :default => '%{namespace}/%{pod_name}'
     config_param :source_category_replace_dash, :string, :default => '/'
@@ -12,7 +12,7 @@ module Fluent
     config_param :source_name, :string, :default => '%{namespace}.%{pod}.%{container}'
     config_param :log_format, :string, :default => 'json'
     config_param :source_host, :string, :default => ''
-
+ 
     config_param :exclude_container_regex, :string, :default => ''
     config_param :exclude_facility_regex, :string, :default => ''
     config_param :exclude_host_regex, :string, :default => ''
@@ -20,58 +20,58 @@ module Fluent
     config_param :exclude_pod_regex, :string, :default => ''
     config_param :exclude_priority_regex, :string, :default => ''
     config_param :exclude_unit_regex, :string, :default => ''
-
+ 
     def configure(conf)
       super
     end
-
+ 
     def is_number?(string)
       true if Float(string) rescue false
     end
-
+ 
     def filter(tag, time, record)
       # Set the sumo metadata fields
       sumo_metadata = record['_sumo_metadata'] || {}
       record['_sumo_metadata'] = sumo_metadata
-
+ 
       sumo_metadata[:log_format] = @log_format
       sumo_metadata[:host] = @source_host if @source_host
       sumo_metadata[:source] = @source_name if @source_name
-
+ 
       unless @source_category.nil?
         sumo_metadata[:category] = @source_category.dup
         unless @source_category_prefix.nil?
           sumo_metadata[:category].prepend(@source_category_prefix)
         end
       end
-
+ 
       if record.key?('_SYSTEMD_UNIT') and not record.fetch('_SYSTEMD_UNIT').nil?
         unless @exclude_unit_regex.empty?
           if Regexp.compile(@exclude_unit_regex).match(record['_SYSTEMD_UNIT'])
             return nil
           end
         end
-
+ 
         unless @exclude_facility_regex.empty?
           if Regexp.compile(@exclude_facility_regex).match(record['SYSLOG_FACILITY'])
             return nil
           end
         end
-
+ 
         unless @exclude_priority_regex.empty?
           if Regexp.compile(@exclude_priority_regex).match(record['PRIORITY'])
             return nil
           end
         end
-
+ 
         unless @exclude_host_regex.empty?
           if Regexp.compile(@exclude_host_regex).match(record['_HOSTNAME'])
             return nil
           end
         end
-
+ 
       end
-
+ 
       # Allow fields to be overridden by annotations
       if record.key?('kubernetes') and not record.fetch('kubernetes').nil?
         # Clone kubernetes hash so we don't override the cache
@@ -82,31 +82,39 @@ module Fluent
             :container => kubernetes['container_name'],
             :source_host => kubernetes['host'],
         }
-
+ 
+        annotations = kubernetes.fetch('annotations', {})
+ 
+        if annotations['sumologic.com/include'] == 'true'
+          include = true
+        else
+          include = false
+        end
+ 
         unless @exclude_namespace_regex.empty?
-          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace])
+          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace]) and not include
             return nil
           end
         end
-
+ 
         unless @exclude_pod_regex.empty?
-          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod])
+          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod]) and not include
             return nil
           end
         end
-
+ 
         unless @exclude_container_regex.empty?
-          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container])
+          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container]) and not include
             return nil
           end
         end
-
+ 
         unless @exclude_host_regex.empty?
-          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host])
+          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host]) and not include
             return nil
           end
         end
-
+ 
         # Strip out dynamic bits from pod name.
         # NOTE: Kubernetes deployments append a template hash.
         pod_parts = k8s_metadata[:pod].split('-')
@@ -115,43 +123,41 @@ module Fluent
         else
           k8s_metadata[:pod_name] = pod_parts[0..-2].join('-')
         end
-
-        annotations = kubernetes.fetch('annotations', {})
-
+ 
         if annotations['sumologic.com/exclude'] == 'true'
           return nil
         end
-
+ 
         sumo_metadata[:log_format] = annotations['sumologic.com/format'] if annotations['sumologic.com/format']
-
+ 
         if annotations['sumologic.com/sourceHost'].nil?
           sumo_metadata[:host] = sumo_metadata[:host] % k8s_metadata
         else
           sumo_metadata[:host] = annotations['sumologic.com/sourceHost'] % k8s_metadata
         end
-
+ 
         if annotations['sumologic.com/sourceName'].nil?
           sumo_metadata[:source] = sumo_metadata[:source] % k8s_metadata
         else
           sumo_metadata[:source] = annotations['sumologic.com/sourceName'] % k8s_metadata
         end
-
+ 
         if annotations['sumologic.com/sourceCategory'].nil?
           sumo_metadata[:category] = sumo_metadata[:category] % k8s_metadata
         else
           sumo_metadata[:category] = (annotations['sumologic.com/sourceCategory'] % k8s_metadata).prepend(@source_category_prefix)
         end
         sumo_metadata[:category].gsub!('-', @source_category_replace_dash)
-
+ 
         # Strip kubernetes metadata from json if disabled
         if annotations['sumologic.com/kubernetes_meta'] == 'false' || !@kubernetes_meta
           record.delete('docker')
           record.delete('kubernetes')
         end
-
+ 
         # Strip sumologic.com annotations
         kubernetes.delete('annotations') if annotations
-
+ 
       end
       record
     end

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -1,10 +1,10 @@
 require 'fluent/filter'
- 
+
 module Fluent
   class SumoContainerOutput < Filter
     # Register type
     Fluent::Plugin.register_filter('kubernetes_sumologic', self)
- 
+
     config_param :kubernetes_meta, :bool, :default => true
     config_param :source_category, :string, :default => '%{namespace}/%{pod_name}'
     config_param :source_category_replace_dash, :string, :default => '/'
@@ -12,7 +12,7 @@ module Fluent
     config_param :source_name, :string, :default => '%{namespace}.%{pod}.%{container}'
     config_param :log_format, :string, :default => 'json'
     config_param :source_host, :string, :default => ''
- 
+
     config_param :exclude_container_regex, :string, :default => ''
     config_param :exclude_facility_regex, :string, :default => ''
     config_param :exclude_host_regex, :string, :default => ''
@@ -20,58 +20,58 @@ module Fluent
     config_param :exclude_pod_regex, :string, :default => ''
     config_param :exclude_priority_regex, :string, :default => ''
     config_param :exclude_unit_regex, :string, :default => ''
- 
+
     def configure(conf)
       super
     end
- 
+
     def is_number?(string)
       true if Float(string) rescue false
     end
- 
+
     def filter(tag, time, record)
       # Set the sumo metadata fields
       sumo_metadata = record['_sumo_metadata'] || {}
       record['_sumo_metadata'] = sumo_metadata
- 
+
       sumo_metadata[:log_format] = @log_format
       sumo_metadata[:host] = @source_host if @source_host
       sumo_metadata[:source] = @source_name if @source_name
- 
+
       unless @source_category.nil?
         sumo_metadata[:category] = @source_category.dup
         unless @source_category_prefix.nil?
           sumo_metadata[:category].prepend(@source_category_prefix)
         end
       end
- 
+
       if record.key?('_SYSTEMD_UNIT') and not record.fetch('_SYSTEMD_UNIT').nil?
         unless @exclude_unit_regex.empty?
           if Regexp.compile(@exclude_unit_regex).match(record['_SYSTEMD_UNIT'])
             return nil
           end
         end
- 
+
         unless @exclude_facility_regex.empty?
           if Regexp.compile(@exclude_facility_regex).match(record['SYSLOG_FACILITY'])
             return nil
           end
         end
- 
+
         unless @exclude_priority_regex.empty?
           if Regexp.compile(@exclude_priority_regex).match(record['PRIORITY'])
             return nil
           end
         end
- 
+
         unless @exclude_host_regex.empty?
           if Regexp.compile(@exclude_host_regex).match(record['_HOSTNAME'])
             return nil
           end
         end
- 
+
       end
- 
+
       # Allow fields to be overridden by annotations
       if record.key?('kubernetes') and not record.fetch('kubernetes').nil?
         # Clone kubernetes hash so we don't override the cache
@@ -82,39 +82,31 @@ module Fluent
             :container => kubernetes['container_name'],
             :source_host => kubernetes['host'],
         }
- 
-        annotations = kubernetes.fetch('annotations', {})
- 
-        if annotations['sumologic.com/include'] == 'true'
-          include = true
-        else
-          include = false
-        end
- 
+
         unless @exclude_namespace_regex.empty?
-          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace]) and not include
+          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace])
             return nil
           end
         end
- 
+
         unless @exclude_pod_regex.empty?
-          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod]) and not include
+          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod])
             return nil
           end
         end
- 
+
         unless @exclude_container_regex.empty?
-          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container]) and not include
+          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container])
             return nil
           end
         end
- 
+
         unless @exclude_host_regex.empty?
-          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host]) and not include
+          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host])
             return nil
           end
         end
- 
+
         # Strip out dynamic bits from pod name.
         # NOTE: Kubernetes deployments append a template hash.
         pod_parts = k8s_metadata[:pod].split('-')
@@ -123,41 +115,43 @@ module Fluent
         else
           k8s_metadata[:pod_name] = pod_parts[0..-2].join('-')
         end
- 
+
+        annotations = kubernetes.fetch('annotations', {})
+
         if annotations['sumologic.com/exclude'] == 'true'
           return nil
         end
- 
+
         sumo_metadata[:log_format] = annotations['sumologic.com/format'] if annotations['sumologic.com/format']
- 
+
         if annotations['sumologic.com/sourceHost'].nil?
           sumo_metadata[:host] = sumo_metadata[:host] % k8s_metadata
         else
           sumo_metadata[:host] = annotations['sumologic.com/sourceHost'] % k8s_metadata
         end
- 
+
         if annotations['sumologic.com/sourceName'].nil?
           sumo_metadata[:source] = sumo_metadata[:source] % k8s_metadata
         else
           sumo_metadata[:source] = annotations['sumologic.com/sourceName'] % k8s_metadata
         end
- 
+
         if annotations['sumologic.com/sourceCategory'].nil?
           sumo_metadata[:category] = sumo_metadata[:category] % k8s_metadata
         else
           sumo_metadata[:category] = (annotations['sumologic.com/sourceCategory'] % k8s_metadata).prepend(@source_category_prefix)
         end
         sumo_metadata[:category].gsub!('-', @source_category_replace_dash)
- 
+
         # Strip kubernetes metadata from json if disabled
         if annotations['sumologic.com/kubernetes_meta'] == 'false' || !@kubernetes_meta
           record.delete('docker')
           record.delete('kubernetes')
         end
- 
+
         # Strip sumologic.com annotations
         kubernetes.delete('annotations') if annotations
- 
+
       end
       record
     end


### PR DESCRIPTION
We tend to exclude whole namespaces from sending data to Sumo to stay below daily quota per our plan. But still sometimes there are certain apps that we'd like to log to sumo for post-mortem analysis or dashboards. This PR makes it possible to annotate pods with `sumologic.com/include=true` and it will take precedence over exclusions made previously with env vars.