### PR TITLE
Add ntp and timesyncd to systemd services

### DIFF
--- a/conf.d/systemd/source.systemd.conf
+++ b/conf.d/systemd/source.systemd.conf
@@ -1040,3 +1040,49 @@
   exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
 </filter>
 
+<source>
+  @type systemd
+  path /mnt/log/journal
+  filters [{"_SYSTEMD_UNIT": "ntp.service"}]
+  <storage>
+    @type local
+    persistent true
+    path /mnt/pos/ntp.log.pos
+  </storage>
+  tag ntp
+</source>
+
+<filter ntp.**>
+  @type kubernetes_sumologic
+  source_category system
+  source_name ntp
+  source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
+  exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
+  exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
+</filter>
+
+<source>
+  @type systemd
+  path /mnt/log/journal
+  filters [{"_SYSTEMD_UNIT": "systemd-timesyncd.service"}]
+  <storage>
+    @type local
+    persistent true
+    path /mnt/pos/systemd-timesyncd.log.pos
+  </storage>
+  tag systemd-timesyncd
+</source>
+
+<filter systemd-timesyncd.**>
+  @type kubernetes_sumologic
+  source_category system
+  source_name systemd-timesyncd
+  source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
+  exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
+  exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
+  exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
+  exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
+</filter>
+


### PR DESCRIPTION
## what

Add ntp and timesyncd to systemd services

## why

Ensuring time is in sync is crucial to the health of the host and k8s cluster