### PR TITLE
If sourceCategory is not present, it will be placed in the sourceCate…

### DIFF
--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -40,9 +40,6 @@ module Fluent
 
       unless @source_category.nil?
         sumo_metadata[:category] = @source_category.dup
-        unless @source_category_prefix.nil?
-          sumo_metadata[:category].prepend(@source_category_prefix)
-        end
       end
 
       if record.key?('_SYSTEMD_UNIT') and not record.fetch('_SYSTEMD_UNIT').nil?
@@ -147,7 +144,6 @@ module Fluent
         else
           sumo_metadata[:category] = (annotations['sumologic.com/sourceCategory'] % k8s_metadata).prepend(@source_category_prefix)
         end
-        sumo_metadata[:category].gsub!('-', @source_category_replace_dash)
 
         # Strip kubernetes metadata from json if disabled
         if annotations['sumologic.com/kubernetes_meta'] == 'false' || !@kubernetes_meta


### PR DESCRIPTION
Sumologic logging is working so much better when we made this change to the plugin as we specify sourceCategory in the configurations, but if they are not present, they are then placed in the sourceCategory specified by the http collector.