### PR TITLE
Add labels to k8s_metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,23 @@ spec:
 
 ```
 
+# Templating Kubernetes metadata
+The following Kubernetes metadata is available for string templating:
+ 
+| String template  | Description                                             |
+| ---------------  | ------------------------------------------------------  |                                         
+| `%{namespace}`   | Namespace name                                          |
+| `%{pod}`         | Full pod name (e.g. `travel-products-4136654265-zpovl`) | 
+| `%{pod_name}`    | Friendly pod name (e.g. `travel-products`)              | 
+| `%{container}`   | Container name                                          |
+| `%{source_host}` | Host                                                    |
+| `%{label:foo}`   | The value of label `foo`                                | 
+
+## Missing labels
+Unlike the other templates, labels are not guaranteed to exist, so missing labels interpolate as `"undefined"`.
+
+For example, if you have only the label `app: travel` but you define `SOURCE_NAME="%{label:app}@%{label:version}"`, the source name will appear as `travel@undefined`.
+
 # Log data
 After performing the configuration described above, your logs should start streaming to SumoLogic in `json` or text format with the appropriate metadata. If you are using `json` format you can auto extract fields, for example `_sourceCategory=some/app | json auto`.
 

--- a/plugins/filter_kubernetes_sumologic.rb
+++ b/plugins/filter_kubernetes_sumologic.rb
@@ -83,6 +83,9 @@ module Fluent
             :source_host => kubernetes['host'],
         }
 
+        kubernetes['labels'].each { |k, v| k8s_metadata["label:#{k}".to_sym] = v }
+        k8s_metadata.default = "undefined"
+
         annotations = kubernetes.fetch('annotations', {})
 
         if annotations['sumologic.com/include'] == 'true'


### PR DESCRIPTION
# Purpose
This PR allows users to specify labels as format strings, e.g.:

```sh
SOURCE_NAME="%{label:app}:%{label:version}"
```

# Technical details
- `kubernetes[:labels][:foo]` is flattened to `k8s_metadata[:"label:foo"]` because the `%` format operator does not allow nested hash lookup - i.e. there is no way to do the following: 
```ruby
%{foo[:bar]} % {foo: {bar: "baz"}}
```

-  `k8s_metadata` sets a default `undefined` value because unlike `namespace`, `pod`, `container` and `source_host`, labels are not guaranteed to exist. In the `SOURCE_NAME` example above, if we have an `app: foo` label but no `version` label, then we will get `foo:undefined` as a source name instead of the more mysterious `foo:`.