### PR TITLE
Add source_host to conf.d/systemd/source.containers.conf

### DIFF
--- a/conf.d/systemd/source.containers.conf
+++ b/conf.d/systemd/source.containers.conf
@@ -22,6 +22,7 @@
 <filter containers.**>
   @type kubernetes_sumologic
   source_name "#{ENV['SOURCE_NAME']}"
+  source_host "#{ENV['SOURCE_HOST']}"
   log_format "#{ENV['LOG_FORMAT']}"
   kubernetes_meta "#{ENV['KUBERNETES_META']}"
   source_category "#{ENV['SOURCE_CATEGORY']}"


### PR DESCRIPTION
It's otherwise impossible to specify a `SOURCE_HOST` when `FLUENTD_SOURCE=systemd`.