### PR TITLE
Add support for send metadata fields as _sumo_metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ lang: ruby
 
 script: bundle exec rake
 
-rvm: 2.3
+rvm: 2.3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ lang: ruby
 
 script: bundle exec rake
 
-rvm: 2.3.7
+rvm: 2.3

--- a/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -168,7 +168,7 @@ module Fluent::Plugin
         kubernetes.delete("annotations") if annotations
 
         if @log_format == "fields"
-          k8s_metadata.each {|k, v| log_fields["#{k}".delete_prefix("label:")] = v}
+          k8s_metadata.each {|k, v| log_fields["#{k}".sub(/^label:/, '')] = v}
         end
       end
 

--- a/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -168,7 +168,7 @@ module Fluent::Plugin
         kubernetes.delete("annotations") if annotations
 
         if @log_format == "fields"
-          k8s_metadata.each {|k, v| log_fields[k] = v}
+          k8s_metadata.each {|k, v| log_fields["#{k}".delete_prefix("label:")] = v}
         end
       end
 

--- a/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -122,7 +122,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         :host => "",
         :log_format => "fields",
         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,namespace=default,pod=log-format-labs-54575ccdb9-9d677,container=log-format-labs,source_host=docker-for-desktop,label:pod-template-hash=1013177865,label:run=log-format-labs,pod_name=log-format-labs-54575ccdb9",
+        :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,namespace=default,pod=log-format-labs-54575ccdb9-9d677,container=log-format-labs,source_host=docker-for-desktop,pod-template-hash=1013177865,run=log-format-labs,pod_name=log-format-labs-54575ccdb9",
       },
     }
     assert_equal(1, d.filtered_records.size)

--- a/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -83,6 +83,52 @@ class SumoContainerOutputTest < Test::Unit::TestCase
     assert_equal(d.filtered_records[0], expected)
   end
 
+  test "test_fields_format" do
+    conf = %{
+      log_format fields
+    }
+    d = create_driver(conf)
+    time = @time
+    input = {
+      "timestamp" => 1538677347823,
+      "log" => "some message",
+      "stream" => "stdout",
+      "docker" => {
+        "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      },
+      "kubernetes" => {
+        "container_name" => "log-format-labs",
+        "namespace_name" => "default",
+        "pod_name" => "log-format-labs-54575ccdb9-9d677",
+        "pod_id" => "170af806-c801-11e8-9009-025000000001",
+        "labels" => {
+          "pod-template-hash" => "1013177865",
+          "run" => "log-format-labs",
+        },
+        "host" => "docker-for-desktop",
+        "master_url" => "https =>//10.96.0.1 =>443/api",
+        "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      },
+    }
+    d.run do
+      d.feed("filter.test", time, input)
+    end
+    expected = {
+      "timestamp" => 1538677347823,
+      "log" => "some message",
+      "stream" => "stdout",
+      "_sumo_metadata" => {
+        :category => "kubernetes/default/log/format/labs/54575ccdb9",
+        :host => "",
+        :log_format => "fields",
+        :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+        :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,namespace=default,pod=log-format-labs-54575ccdb9-9d677,container=log-format-labs,source_host=docker-for-desktop,label:pod-template-hash=1013177865,label:run=log-format-labs,pod_name=log-format-labs-54575ccdb9",
+      },
+    }
+    assert_equal(1, d.filtered_records.size)
+    assert_equal(d.filtered_records[0], expected)
+  end
+
   test "test_no_k8s_labels" do
     conf = %{}
     d = create_driver(conf)


### PR DESCRIPTION
As part of efforts to support sending log metadata fields, introducing a new log_format `fields`. When set, we will pick all the docker & kubernetes fields from the record & dump them to a special field under _sumo_metadata. 

The handling of the new field is part of proposed changes: https://github.com/SumoLogic/fluentd-output-sumologic/pull/34 