### PR TITLE
readme: document K8S_NODE_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Environment | Variable Description
 `K8S_METADATA_FILTER_BEARER_TOKEN_FILE`|Option to control the enabling of [metadata filter plugin bearer_token_file](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration).
 `K8S_METADATA_FILTER_BEARER_CACHE_SIZE`|Option to control the enabling of [metadata filter plugin cache_size](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration). Default: `1000`
 `K8S_METADATA_FILTER_BEARER_CACHE_TTL`|Option to control the enabling of [metadata filter plugin cache_ttl](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration). Default: `3600`
+`K8S_NODE_NAME`|If set, improves [caching of pod metadata](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes) and reduces API calls. 
 
 
 The following table show which  environment variables affect which Fluentd sources.


### PR DESCRIPTION
Adds documentation for the [`K8S_NODE_NAME`](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes) variable supported by the metadata filter. 

This explains the idea behind the change: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/124

Namely: the filter listens on events to help cache metadata on the pods that live on that node. For very short-lived pods (esp. jobs) the filter might get a 404 from the api because the pod is gone but fluentd is still processing its logs.

I'll add this to the helm chart so that users are opted in by default!