### PR TITLE
Polish "reduce metadata" feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler (~> 2)
   codecov
   fluent-plugin-kubernetes_sumologic!
   rake
@@ -75,4 +75,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.3
+   2.0.1

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Environment | Variable Description
 `FLUENTD_USER_CONFIG_DIR`|A directory of user-defined fluentd configuration files, which must be in the  `*.conf` directory in the container.
 `FLUSH_INTERVAL` |How frequently to push logs to Sumo.<br/><br/>Default: `5s`
 `KUBERNETES_META`|Include or exclude Kubernetes metadata such as `namespace` and `pod_name` if using JSON log format. <br/><br/>Default: `true`
-`KUBERNETES_META_REDUCE`| Reduces Kubernetes metadata, check [Reducing Kubernetes Metadata](#####reduce-kubernetes-metadata-using-annotations). <br></br>Default: `false`
+`KUBERNETES_META_REDUCE`| Reduces redundant Kubernetes metadata, see [_Reducing Kubernetes Metadata_](#reducing-kubernetes-metadata). <br></br>Default: `false`
 `LOG_FORMAT`|Format in which to post logs to Sumo. Allowable values:<br/><br/>`text`—Logs will appear in SumoLogic in text format.<br/>`json`—Logs will appear in SumoLogic in json format.<br/>`json_merge`—Same as json but if the container logs in json format to stdout it will merge in the container json log at the root level and remove the log field.<br/><br/>Default: `json`
 `MULTILINE_START_REGEXP`|The regular expression for the `concat` plugin to use when merging multi-line messages. Defaults to Julian dates, for example, Jul 29, 2017.
 `NUM_THREADS`|Set the number of HTTP threads to Sumo. It might be necessary to do so in heavy-logging clusters. <br/><br/>Default: `1`
@@ -147,6 +147,53 @@ The following table show which  environment variables affect which Fluentd sourc
 ### FluentD stops processing logs
 When dealing with large volumes of data (TB's from what we have seen), FluentD may stop processing logs, but continue to run.  This issue seems to be caused by the [scalability of the inotify process](https://github.com/fluent/fluentd/issues/1630) that is packaged with the FluentD in_tail plugin.  If you encounter this situation, setting the `ENABLE_STAT_WATCHER` to `false` should resolve this issue.
 
+### Reducing Kubernetes metadata
+
+You can use the `KUBERNETES_META_REDUCE` environment variable (global) or the `sumologic.com/kubernetes_meta_reduce` annotation (per pod) to reduce the amount of Kubernetes metadata included with each log line under the `kubernetes` field. 
+
+When set, FluentD will remove the following properties:
+
+* `pod_id`
+* `container_id`
+* `namespace_id`
+* `master_url`
+* `labels`
+* `annotations`
+
+Logs will still include:
+
+* `pod_name`
+* `container_name`
+* `namespace_name`
+* `host`
+
+These fields still allow you to uniquely identify a pod and look up additional details with the Kubernetes API.
+
+```yaml
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    app: mywebsite
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: mywebsite
+      annotations:
+        sumologic.com/kubernetes_meta_reduce: "true"
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+```
+
+
 ### Override environment variables using annotations
 You can override the `LOG_FORMAT`, `KUBERNETES_META_REDUCE`, `SOURCE_CATEGORY` and `SOURCE_NAME` environment variables, per pod, using [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/). For example:
 
@@ -169,33 +216,6 @@ spec:
         sumologic.com/kubernetes_meta_reduce: "true"
         sumologic.com/sourceCategory: "mywebsite/nginx"
         sumologic.com/sourceName: "mywebsite_nginx"
-    spec:
-      containers:
-      - name: nginx
-        image: nginx
-        ports:
-        - containerPort: 80
-```
-
-### Reduce Kubernetes Metadata using annotations
-You can also use the "sumologic.com/kubernetes_meta_reduce" annotation to exclude `pod_id`, 
-`container_id`, `namespace_id`, `namespace_name`, `master_url` and `labels` from Kubernetes Metadata.
-```
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: nginx
-spec:
-  replicas: 1
-  selector:
-    app: mywebsite
-  template:
-    metadata:
-      name: nginx
-      labels:
-        app: mywebsite
-      annotations:
-        sumologic.com/kubernetes_meta_reduce: "true"
     spec:
       containers:
       - name: nginx

--- a/fluent-plugin-kubernetes_sumologic.gemspec
+++ b/fluent-plugin-kubernetes_sumologic.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_development_dependency "bundler", "~> 1.3"
+  gem.add_development_dependency "bundler", "~> 2"
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'test-unit', '~> 3.1.0'
   gem.add_development_dependency "codecov", ">= 0.1.10"

--- a/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -183,7 +183,6 @@ module Fluent::Plugin
           record["kubernetes"].delete("namespace_id")
           record["kubernetes"].delete("labels")
           record["kubernetes"].delete("master_url")
-          record["kubernetes"].delete("namespace_name")
           record["kubernetes"].delete("annotations")
         end
         if @add_stream == false

--- a/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -458,6 +458,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             "container_name" => "log-format-labs",
             "pod_name" => "log-format-labs-54575ccdb9-9d677",
             "host" => "docker-for-desktop",
+            "namespace_name" => "default",
         },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
@@ -506,6 +507,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             "container_name" => "log-format-labs",
             "pod_name" => "log-format-labs-54575ccdb9-9d677",
             "host" => "docker-for-desktop",
+            "namespace_name" => "default",
         },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",

--- a/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -557,6 +557,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             "container_name" => "log-format-labs",
             "pod_name" => "log-format-labs-54575ccdb9-9d677",
             "host" => "docker-for-desktop",
+            "namespace_name" => "default",
         },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",


### PR DESCRIPTION
We noticed our log volume has been increasing pretty steadily as we move apps onto Kubernetes while the line count has remained unchanged. We attributed this to the additional k8s metadata in each line. While we include some bits of data in the `_source*` fields, we do want to keep _some_ info around to ensure we can identify every pod from its logs. Was super pleased to discover that this was added a month ago!

I noticed that the docs needed some love and that a property was missing. Changes:

* Includes `namespace_name` as described in the [original PR](https://github.com/SumoLogic/fluentd-kubernetes-sumologic/pull/92#issue-227244230). Without a namespace, a pod cannot be uniquely identified.
* Adds full documentation around which properties are excluded/included and why
* Avoids focusing on the annotation part of the feature (mentions the global env var and emphasizes behavior over configuration).
* Fixes broken TOC link
* Updates to bundler@2 (unrelated, but required to run tests)