### PR TITLE
support %{pod_id} interpolation in source metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ The following Kubernetes metadata is available for string templating:
 | `%{namespace}`   | Namespace name                                          |
 | `%{pod}`         | Full pod name (e.g. `travel-products-4136654265-zpovl`) | 
 | `%{pod_name}`    | Friendly pod name (e.g. `travel-products`)              | 
+| `%{pod_id}`      | The pod's uid (a UUID)                                  | 
 | `%{container}`   | Container name                                          |
 | `%{source_host}` | Host                                                    |
 | `%{label:foo}`   | The value of label `foo`                                | 

--- a/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -104,6 +104,7 @@ module Fluent::Plugin
         k8s_metadata = {
           :namespace => kubernetes["namespace_name"],
           :pod => kubernetes["pod_name"],
+          :pod_id => kubernetes['pod_id'],
           :container => kubernetes["container_name"],
           :source_host => kubernetes["host"],
         }

--- a/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -1065,6 +1065,67 @@ class SumoContainerOutputTest < Test::Unit::TestCase
     assert_equal(d.filtered_records[0], expected)
   end
 
+  test "test_sourcehost_using_pod_id" do
+    conf = %{
+      source_host %{pod_id}
+    }
+    d = create_driver(conf)
+    time = @time
+    input = {
+      "timestamp" => 1538677347823,
+      "log" => "some message",
+      "stream" => "stdout",
+      "docker" => {
+        "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      },
+      "kubernetes" => {
+        "container_name" => "log-format-labs",
+        "namespace_name" => "default",
+        "pod_name" => "log-format-labs-54575ccdb9-9d677",
+        "pod_id" => "170af806-c801-11e8-9009-025000000001",
+        "labels" => {
+          "pod-template-hash" => "1013177865",
+          "run" => "log-format-labs",
+        },
+        "host" => "docker-for-desktop",
+        "master_url" => "https =>//10.96.0.1 =>443/api",
+        "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      },
+    }
+    d.run do
+      d.feed("filter.test", time, input)
+    end
+    expected = {
+      "timestamp" => 1538677347823,
+      "log" => "some message",
+      "stream" => "stdout",
+      "docker" => {
+        "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      },
+      "kubernetes" => {
+        "container_name" => "log-format-labs",
+        "namespace_name" => "default",
+        "pod_name" => "log-format-labs-54575ccdb9-9d677",
+        "pod_id" => "170af806-c801-11e8-9009-025000000001",
+        "labels" => {
+          "pod-template-hash" => "1013177865",
+          "run" => "log-format-labs",
+        },
+        "host" => "docker-for-desktop",
+        "master_url" => "https =>//10.96.0.1 =>443/api",
+        "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      },
+      "_sumo_metadata" => {
+        :category => "kubernetes/default/log/format/labs",
+        :host => "170af806-c801-11e8-9009-025000000001",
+        :log_format => "json",
+        :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+      },
+    }
+    assert_equal(1, d.filtered_records.size)
+    assert_equal(d.filtered_records[0], expected)
+  end
+
   test "test_undefined_labels" do
     conf = %{
       source_category %{namespace}/%{pod_name}/%{label:foo}


### PR DESCRIPTION
Adds support for interpolating the `pod_id` in source metadata. This is useful because none of the other values is unique. 

* `pod_name` is sanitized such that pods in a ReplicaSet have the same name. 
* `host` will be the same for pods on the same host

If you want to answer the question "how many unique pods logged during this time window," you need the `pod_id`. While it's available in the `kubernetes` metadata field, I figured it should be available in the source metadata too for users who have metadata off/reduced.