### PR TITLE
Add /u01 mount for running fluentd plugin under OCI OKE

### DIFF
--- a/daemonset/nonrbac/fluentd.yaml
+++ b/daemonset/nonrbac/fluentd.yaml
@@ -16,6 +16,10 @@ spec:
         hostPath:
           path: /var/run/fluentd-pos
           type: ""
+      # User data 1 mount point for Kubernetes running in OCI Container Engine for Kubernetes (OKE)
+      - name: "u01"
+        hostPath:
+          path: /u01
       - name: host-logs
         hostPath:
           path: /var/log/
@@ -40,6 +44,9 @@ spec:
           readOnly: true
         - name: docker-logs
           mountPath: /var/lib/docker/
+          readOnly: true
+        - name: "u01"
+          mountPath: /u01
           readOnly: true
         - name: pos-files
           mountPath: /mnt/pos/


### PR DESCRIPTION
Add /u01 mount for running fluentd plugin under OCI OKE where directories under /var/log point to directories under /u01.

Without this change the sumo logic fluentd will report that logs are unreadable as logged below:

```
2019-05-14 20:17:13 +0000 [warn]: #0 /mnt/log/containers/chokuto-production-6cdcc749bc-9mkcv_default_app-7058471906c73111293f6fd892e7057d8d71d9a9ef756272ee429638e3224ee9.log unreadable. It is excluded and would be examined next time.
```

After further examination,``` chokuto-production-6cdcc749bc-9mkcv_default_app-7058471906c73111293f6fd892e7057d8d71d9a9ef756272ee429638e3224ee9.log``` is stored under the ```/u01/data/docker/containers/``` path in the node's filesystem.

This fixes #130 