### PR TITLE
pull v2.4.1 docker image explicitly

### DIFF
--- a/daemonset/nonrbac/fluentd.yaml
+++ b/daemonset/nonrbac/fluentd.yaml
@@ -30,7 +30,7 @@ spec:
         configMap:
           name: fluentd-sumologic-config
       containers:
-      - image: sumologic/fluentd-kubernetes-sumologic:latest
+      - image: sumologic/fluentd-kubernetes-sumologic:v2.4.1
         name: fluentd
         imagePullPolicy: Always
         volumeMounts:

--- a/daemonset/rbac/fluentd.yaml
+++ b/daemonset/rbac/fluentd.yaml
@@ -65,7 +65,7 @@ spec:
         configMap:
           name: fluentd-sumologic-config
       containers:
-      - image: sumologic/fluentd-kubernetes-sumologic:latest
+      - image: sumologic/fluentd-kubernetes-sumologic:v2.4.1
         name: fluentd
         imagePullPolicy: Always
         volumeMounts:


### PR DESCRIPTION
https://github.com/SumoLogic/fluentd-kubernetes-sumologic/issues/135

The `latest` tag now points to `v2.3.2`, and we should explicitly pull the image from `v2.4.1` in the master branch.