### PR TITLE
remove updating latest tag in ci script

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -22,16 +22,14 @@ bundle exec rake
 echo "Build gem $PLUGIN_NAME $VERSION..."
 gem build $PLUGIN_NAME
 
-echo "Building docker image with $DOCKER_TAG:$VERSION and $DOCKER_TAG:latest in `pwd`..."
+echo "Building docker image with $DOCKER_TAG:$VERSION in `pwd`..."
 docker build . -f ./Dockerfile -t $DOCKER_TAG:v$VERSION --no-cache
-docker build . -f ./Dockerfile -t $DOCKER_TAG:latest
 if [ -z "$DOCKER_PASSWORD" ] || [ -z "$TRAVIS_TAG" ]; then
     echo "Skip Docker pushing"
 else
-    echo "Pushing docker image with $DOCKER_TAG:$VERSION and $DOCKER_TAG:latest..."
+    echo "Pushing docker image with $DOCKER_TAG:$VERSION..."
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     docker push $DOCKER_TAG:v$VERSION
-    docker push $DOCKER_TAG:latest
 fi
 
 rm -f ./*.gem


### PR DESCRIPTION
By cutting release `v2.4.2`, it inadvertently updated `latest` to this as well, when we had previously set it to `v2.3.2` to avoid backwards incompatible changes. I'm removing the `latest` tag from the script for this reason.

In the meantime I manually updated `latest` to point to `v2.3.2` again.