### PR TITLE
filter out empty values in log fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 lang: ruby
-rvm:
-  - 2.4.4
 services: docker
 before_install:
   - rm -f ./Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 lang: ruby
+rvm:
+  - 2.4.4
 services: docker
 before_install:
   - rm -f ./Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM fluent/fluentd:v1.3.2-debian AS builder
+FROM fluent/fluentd:v1.4.2-debian-2.0 AS builder
 
-ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
+ENV PATH /home/fluent/.gem/ruby/2.5.0/bin:$PATH
 
 COPY ./fluent-plugin-kubernetes_sumologic*.gem ./
+
+USER root
 
 # New fluent image dynamically creates user in entrypoint
 RUN [ -f /bin/entrypoint.sh ] && /bin/entrypoint.sh echo || : && \
@@ -17,7 +19,7 @@ RUN [ -f /bin/entrypoint.sh ] && /bin/entrypoint.sh echo || : && \
     gem install fluent-plugin-rewrite-tag-filter -v 2.1.0 && \
     gem install fluent-plugin-prometheus -v 1.1.0 && \
     gem install fluent-plugin-kubernetes_sumologic && \
-    rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && \
+    rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem && \
     gem sources -c && \
     apt-get remove --purge -y build-essential ruby-dev libffi-dev libsystemd-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -25,7 +27,7 @@ RUN [ -f /bin/entrypoint.sh ] && /bin/entrypoint.sh echo || : && \
 FROM fluent/fluentd:v1.3.2-debian
 
 WORKDIR /home/fluent
-ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
+ENV PATH /home/fluent/.gem/ruby/2.5.0/bin:$PATH
 
 RUN mkdir -p /mnt/pos
 EXPOSE 24284

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fluent/fluentd:v1.7.0-debian-1.0 AS builder
 
-ENV PATH /home/fluent/.gem/ruby/2.5.0/bin:$PATH
+ENV PATH /home/fluent/.gem/ruby/2.6.0/bin:$PATH
 
 COPY ./fluent-plugin-kubernetes_sumologic*.gem ./
 
@@ -19,17 +19,17 @@ RUN [ -f /bin/entrypoint.sh ] && /bin/entrypoint.sh echo || : && \
     gem install fluent-plugin-rewrite-tag-filter -v 2.1.0 && \
     gem install fluent-plugin-prometheus -v 1.1.0 && \
     gem install fluent-plugin-kubernetes_sumologic && \
-    rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem && \
+    rm -rf /home/fluent/.gem/ruby/2.6.0/cache/*.gem && \
     gem sources -c && \
     apt-get remove --purge -y build-essential ruby-dev libffi-dev libsystemd-dev && \
     rm -rf /var/lib/apt/lists/*
 
 FROM fluent/fluentd:v1.7.0-debian-1.0
 
-WORKDIR /home/fluent
-ENV PATH /home/fluent/.gem/ruby/2.5.0/bin:$PATH
-
 USER root
+
+WORKDIR /home/fluent
+ENV PATH /home/fluent/.gem/ruby/2.6.0/bin:$PATH
 
 RUN mkdir -p /mnt/pos
 EXPOSE 24284
@@ -68,9 +68,9 @@ ENV VERIFY_SSL "true"
 ENV FORWARD_INPUT_BIND "0.0.0.0"
 ENV FORWARD_INPUT_PORT "24224"
 
-COPY --from=builder /var/lib/gems /var/lib/gems
+COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY ./entrypoint.sh /fluentd/
 
-USER docker
+USER fluent
 
 ENTRYPOINT ["/fluentd/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.4.2-debian-2.0 AS builder
+FROM fluent/fluentd:v1.7.0-debian-1.0 AS builder
 
 ENV PATH /home/fluent/.gem/ruby/2.5.0/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,12 @@ RUN [ -f /bin/entrypoint.sh ] && /bin/entrypoint.sh echo || : && \
     apt-get remove --purge -y build-essential ruby-dev libffi-dev libsystemd-dev && \
     rm -rf /var/lib/apt/lists/*
 
-FROM fluent/fluentd:v1.3.2-debian
+FROM fluent/fluentd:v1.7.0-debian-1.0
 
 WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.5.0/bin:$PATH
+
+USER root
 
 RUN mkdir -p /mnt/pos
 EXPOSE 24284
@@ -68,5 +70,7 @@ ENV FORWARD_INPUT_PORT "24224"
 
 COPY --from=builder /var/lib/gems /var/lib/gems
 COPY ./entrypoint.sh /fluentd/
+
+USER docker
 
 ENTRYPOINT ["/fluentd/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,4 @@ ENV FORWARD_INPUT_PORT "24224"
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY ./entrypoint.sh /fluentd/
 
-USER fluent
-
 ENTRYPOINT ["/fluentd/entrypoint.sh"]

--- a/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -221,7 +221,7 @@ module Fluent::Plugin
       end
 
       if @log_format == "fields" and not log_fields.nil?
-        sumo_metadata[:fields] = log_fields.map{|k,v| "#{k}=#{v}"}.join(',')
+        sumo_metadata[:fields] = log_fields.select{|k,v| !(v.nil? || v.empty?)}.map{|k,v| "#{k}=#{v}"}.join(',')
         record.delete("docker")
         record.delete("kubernetes")
       end


### PR DESCRIPTION
Since our backend cannot accept empty values for logs metadata, we filter out any empty values.